### PR TITLE
feat: update README and improve behavior with no arguments, or when there is an error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## Getting Started
 
-The Topos Playground is a CLI that allows you to easily run and manage a local Topos devnet. It depends on Docker and NodeJS, and manages a number of components in order to locally run multiple subnets, multiple TCE nodes, and a dApp with supporting infrastructure, capable of cross-subnet messaging.
+The Topos Playground is a CLI that allows you to easily run and manage a local Topos devnet. It depends on Docker and NodeJS, and manages a number of components in order to locally run multiple subnets, multiple TCE nodes, and a dApp with supporting infrastructure, capable of cross-subnet messaging. For additional information about Topos and about this Playground CLI, take a look at the [Topos Developer Portal](https://docs.topos.technology).
 
 ### Requirements
 
@@ -101,6 +101,8 @@ To disable this, you can use the `--quiet` flag to prevent output from going to 
 $ topos-playground clean --quiet
 ```
 
+For more in-depth discussion about the playground components, and what the `topos-playground` is doing, take a look at the [Topos Playground components](https://docs.topos.technology/content/module-2/3-components.html) portion of the Topos Developer Portal.
+
 ### Development
 
 To contribute to the development of the playground, [fork](https://github.com/topos-protocol/topos-playground/fork) the repository.
@@ -144,6 +146,16 @@ If you manually installed and started Redis, you will need to manually stop it.
 $ redis-cli shutdown
 ```
 
+* `docker: Error response from daemon: Conflict. The container name "/redis-stack-server" is already in use by container "1ccdeb3adf2259168a5f74697013eaab8d61fb18e123e0a4d06545ac4269cc94". You have to remove (or rename) that container to be able to reuse that name.`
+
+This error indicates that the `redis-stack-server` container is already running. This is likely because you have already ran the playground, but a `topos-playground clean` was never ran. To fix this, run `topos-playground clean` and then try again.
+
+This may also sometimes occur if you have a local redis instance running. Refer to the instructions above for how to shut down a local redis instance.
+
+* `Error: service "contracts-incal" didn't complete successfully: exit 1`
+
+One cause of this error is a previous failure when starting the playground that wasn't cleaned up by running `topos-playground clean`. To fix this, run `topos-playground clean` and then try again.
+
 * `Error: info: unknown shorthand flag: 'd' in -d`
 
 If you see this error, you likely do not have Docker Compose installed. You need version 2 or greater. Refer to the [Docker Compose installation instructions](https://docs.docker.com/compose/install/) for your platform.
@@ -157,10 +169,6 @@ The quick fix for this is to shut down your VPN, and then try to run the playgro
 * `Error: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`
 
 If this error occurs, it likely means that your `dockerd` daemon is not running. Please consult the documentation for your OS and Docker installation to determine how to correctly restart it for your platform.
-
-* `docker: Error response from daemon: Conflict. The container name "/redis-stack-server" is already in use by container "1ccdeb3adf2259168a5f74697013eaab8d61fb18e123e0a4d06545ac4269cc94". You have to remove (or rename) that container to be able to reuse that name.`
-
-This error indicates that the `redis-stack-server` container is already running. This is likely because you have already ran the playground, but a `topos-playground clean` was never ran. To fix this, run `topos-playground clean` and then try again.
 
 * `Error: Error response from daemon: driver failed programming external connectivity on endpoint infra-tce-boot-1 (145130455efa244316eb0570064adb584e2c99d18fa2cd8f58b2774f1144d2bb):  (iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 0/0 --dport 32807 -j DNAT --to-destination 172.21.0.9:9090 ! -i br-de97b637b33b: iptables v1.8.7 (nf_tables): unknown option "--to-destination"`
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ The Topos Playground is a CLI that allows you to easily run and manage a local T
 ### Requirements
 
 - [Docker](https://docs.docker.com/get-docker/_) version 17.06.0 or greater
+- [Docker Compose](https://docs.docker.com/compose/install/) version 2.0.0 or greater
 - [NodeJS](https://nodejs.dev/en/) version 16.0.0 or greater
 - Git
 

--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ The likely cause of this error is that you are running a VPN of some sort.
 
 The quick fix for this is to shut down your VPN, and then try to run the playground again.
 
+* `Error: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?`
+
+If this error occurs, it likely means that your `dockerd` daemon is not running. Please consult the documentation for your OS and Docker installation to determine how to correctly restart it for your platform.
+
+* `docker: Error response from daemon: Conflict. The container name "/redis-stack-server" is already in use by container "1ccdeb3adf2259168a5f74697013eaab8d61fb18e123e0a4d06545ac4269cc94". You have to remove (or rename) that container to be able to reuse that name.`
+
+This error indicates that the `redis-stack-server` container is already running. This is likely because you have already ran the playground, but a `topos-playground clean` was never ran. To fix this, run `topos-playground clean` and then try again.
+
 * `Error: Error response from daemon: driver failed programming external connectivity on endpoint infra-tce-boot-1 (145130455efa244316eb0570064adb584e2c99d18fa2cd8f58b2774f1144d2bb):  (iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 0/0 --dport 32807 -j DNAT --to-destination 172.21.0.9:9090 ! -i br-de97b637b33b: iptables v1.8.7 (nf_tables): unknown option "--to-destination"`
 
 If this error occurs, you are running Linux, and you have recently done an OS upgrade, try rebooting your system. If the problem persists, first ensure that you can load the 'xt_nat' kernel module:

--- a/README.md
+++ b/README.md
@@ -144,6 +144,10 @@ If you manually installed and started Redis, you will need to manually stop it.
 $ redis-cli shutdown
 ```
 
+* `Error: info: unknown shorthand flag: 'd' in -d`
+
+If you see this error, you likely do not have Docker Compose installed. You need version 2 or greater. Refer to the [Docker Compose installation instructions](https://docs.docker.com/compose/install/) for your platform.
+
 * `Error: failed to create network local-erc20-messaging-infra-docker: Error response from daemon: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network`
 
 The likely cause of this error is that you are running a VPN of some sort.

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ For community help or discussion, you can join the Topos Discord server:
 
 ### Troubleshooting
 
-#### `Running the redis server...❗ Error`
+* `Running the redis server...❗ Error`
 
 The container that provides the Redis service was unable to start. This is likely because you are already running a Redis instance on your system. Try shutting it down.
 
@@ -143,13 +143,13 @@ If you manually installed and started Redis, you will need to manually stop it.
 $ redis-cli shutdown
 ```
 
-#### `Error: failed to create network local-erc20-messaging-infra-docker: Error response from daemon: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network`
+* `Error: failed to create network local-erc20-messaging-infra-docker: Error response from daemon: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network`
 
 The likely cause of this error is that you are running a VPN of some sort.
 
 The quick fix for this is to shut down your VPN, and then try to run the playground again.
 
-#### `Error: Error response from daemon: driver failed programming external connectivity on endpoint infra-tce-boot-1 (145130455efa244316eb0570064adb584e2c99d18fa2cd8f58b2774f1144d2bb):  (iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 0/0 --dport 32807 -j DNAT --to-destination 172.21.0.9:9090 ! -i br-de97b637b33b: iptables v1.8.7 (nf_tables): unknown option "--to-destination"`
+* `Error: Error response from daemon: driver failed programming external connectivity on endpoint infra-tce-boot-1 (145130455efa244316eb0570064adb584e2c99d18fa2cd8f58b2774f1144d2bb):  (iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 0/0 --dport 32807 -j DNAT --to-destination 172.21.0.9:9090 ! -i br-de97b637b33b: iptables v1.8.7 (nf_tables): unknown option "--to-destination"`
 
 If this error occurs, you are running Linux, and you have recently done an OS upgrade, try rebooting your system. If the problem persists, first ensure that you can load the 'xt_nat' kernel module:
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ npm run build && npm link
 
 ### Run the CLI
 
-If you have installed the via `npm` or `yarn`, you can run the CLI like any other command line tool:
+If you have installed the via `npm`, `yarn`, or manually after building it from the git repository, you can run the CLI like any other command line tool:
 
 ```
 $ topos-playground --help

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ This will check that the required prerequisites are met, and will then setup and
 $ topos-playground clean
 ```
 
-To clean up any still-running docker containers or filesystem artifacts from a previous invocation of the tops-playground, use the `clean` command.
+To clean up any still-running docker containers or filesystem artifacts from a previous invocation of the topos-playground, use the `clean` command.
 
 The playground respects XDG Base Directory Specifications, so by default, it will store
 data used while running in `$HOME/.local/share/topos-playground` and it will store logs

--- a/README.md
+++ b/README.md
@@ -5,32 +5,81 @@
   <img src="./.github/assets/topos_logo_dark.png#gh-dark-mode-only" alt="Logo" width="200">
   <br />
   <p align="center">
-  <b>Topos Playground</b> is a CLI make it simple to run a local Topos devnet 🚀
+  <b>Topos Playground</b> is a CLI to make it simple to run a local Topos devnet 🚀
   </p>
   <br />
 </div>
 
 ## Getting Started
 
+The Topos Playground is a CLI that allows you to easily run and manage a local Topos devnet. It depends on Docker and NodeJS, and manages a number of components in order to locally run multiple subnets, multiple TCE nodes, and a dApp with supporting infrastructure, capable of cross-subnet messaging.
+
 ### Requirements
 
+- [Docker](https://docs.docker.com/get-docker/_) version 17.06.0 or greater
+- [NodeJS](https://nodejs.dev/en/) version 16.0.0 or greater
 - Git
-- NodeJS (tested with 16+)
-- Docker
 
-### [Optional] Install the package globally
+### Install / Run topos-playground
+
+Depending on your NodeJS environment and preferences, there are several ways to install the Topos Playground.
+
+To install the playground globally, using `npm`, run the following command:
 
 ```
 $ npm install -g @topos-protocol/topos-playground
 ```
 
+To install the playground globally, using `yarn`, run the following command:
+
+```
+$ yarn global add @topos-protocol/topos-playground
+```
+
+Alternatively, you can install and run via `npx`:
+
+```
+$ npx @topos-protocol/topos-playground
+```
+
+#### Install via Git
+
+If you prefer to install the playground via Git, you can clone the repository and install it manually.
+
+```
+$ git clone https://github.com/topos-protocol/topos-playground.git
+$ cd topos-playground
+$ npm install
+$ npm run build && npm link
+```
+
 ### Run the CLI
 
-If you have installed the package manually, you can run it like so:
+If you have installed the via `npm` or `yarn`, you can run the CLI like any other command line tool:
 
 ```
 $ topos-playground --help
 ```
+
+If you are using `npx`, you will run it via `npx`:
+
+```
+$ npx @topos-protocol/topos-playground --help
+```
+
+Topos Playground supports two subcommands, `start` and `clean`.
+
+```
+$ topos-playground start
+```
+
+This will check that the required prerequisites are met, and will then setup and start all of the containers for a complete local Topos network. It will report progress to the console as well as logging to a file.
+
+```
+$ topos-playground clean
+```
+
+To clean up any still-running docker containers or filesystem artifacts from a previous invocation of the tops-playground, use the `clean` command.
 
 The playground respects XDG Base Directory Specifications, so by default, it will store
 data used while running in `$HOME/.local/share/topos-playground` and it will store logs
@@ -48,25 +97,84 @@ To disable this, you can use the `--quiet` flag to prevent output from going to 
 `--no-log` flag to prevent output from going to the log file.
 
 ```
-$ topos-playground start --quiet
+$ topos-playground clean --quiet
 ```
 
-Otherwise, you can use `npx` to abstract the installation
+### Development
+
+To contribute to the development of the playground, [fork](https://github.com/topos-protocol/topos-playground/fork) the repository.
+
+Do your work within a branch on your fork. When it is ready, create a Pull Request that clearly explains the reasoning behind your code changes, what they do, and anything that we should be aware of when testing your code.
+
+### Discussion
+
+For community help or discussion, you can join the Topos Discord server:
+
+[https://discord.gg/zMCqqCbGMV](https://discord.gg/zMCqqCbGMV)
+
+### Troubleshooting
+
+#### `Running the redis server...❗ Error`
+
+The container that provides the Redis service was unable to start. This is likely because you are already running a Redis instance on your system. Try shutting it down.
+
+On Linux:
 
 ```
-$ npx @topos-protocol/topos-plaground [start|clean]
+$ sudo systemctl stop redis-server
 ```
 
-## Development
+or
 
-### Build
-
-```
-npm run build
-```
-
-### Rum
 
 ```
-node dist/main [start|clean]
+$ sudo service redis-server stop
 ```
+
+On MacOS:
+
+```
+brew services stop redis
+```
+
+If you manually installed and started Redis, you will need to manually stop it.
+
+```
+$ redis-cli shutdown
+```
+
+#### `Error: failed to create network local-erc20-messaging-infra-docker: Error response from daemon: could not find an available, non-overlapping IPv4 address pool among the defaults to assign to the network`
+
+The likely cause of this error is that you are running a VPN of some sort.
+
+The quick fix for this is to shut down your VPN, and then try to run the playground again.
+
+#### `Error: Error response from daemon: driver failed programming external connectivity on endpoint infra-tce-boot-1 (145130455efa244316eb0570064adb584e2c99d18fa2cd8f58b2774f1144d2bb):  (iptables failed: iptables --wait -t nat -A DOCKER -p tcp -d 0/0 --dport 32807 -j DNAT --to-destination 172.21.0.9:9090 ! -i br-de97b637b33b: iptables v1.8.7 (nf_tables): unknown option "--to-destination"`
+
+If this error occurs, you are running Linux, and you have recently done an OS upgrade, try rebooting your system. If the problem persists, first ensure that you can load the 'xt_nat' kernel module:
+
+```
+$ sudo modprobe xt_nat
+```
+
+If that command fails, then this is likely the problem. You can try to load the module manually:
+
+```
+$ sudo insmod /lib/modules/$(uname -r)/kernel/net/netfilter/xt_nat.ko
+```
+
+And then try again.
+
+If that command succeeds, but the problem persists, check your iptables version:
+
+```
+$ iptables --version
+```
+
+It should show something like this:
+
+```
+iptables v1.8.7 (nf_tables)
+```
+
+If the `nf_tables` is absent, and you have already tried to reboot, investigate your `/usr/sbin/iptables` symlink. It should point to `/usr/sbin/xtables-nft-multi`. It should, either via a direct link, or perhaps through a chain of symlinks, point to `/usr/sbin/xtables-nft-multi`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
   <img src="./.github/assets/topos_logo_dark.png#gh-dark-mode-only" alt="Logo" width="200">
   <br />
   <p align="center">
-  <b>Topos Playground</b> is a CLI to make it simple to run a local Topos devnet 🚀
+  <b>Topos Playground</b> is a CLI (command-line interface) to run a local Topos devnet 🚀
   </p>
   <br />
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@topos-protocol/topos-playground",
-  "version": "0.0.2",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@topos-protocol/topos-playground",
-      "version": "0.0.2",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@nestjs/common": "^9.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@topos-protocol/topos-playground",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "topos-playground is a CLI tool which handles all of the orchestration necessary to run local Topos devnets with subnets, a TCE network, and apps.",
   "author": "Sébastien Dan <sebastien.dan@gmail.com>",
   "license": "MIT",

--- a/src/ReactiveSpawn.ts
+++ b/src/ReactiveSpawn.ts
@@ -14,6 +14,7 @@ export class ReactiveSpawn {
 
   reactify(command: string, options?: { runInBackground }) {
     return new Observable<Next>((subscriber) => {
+      let errBuffer = []
       if (globalThis.verbose) {
         log(`🏃 Running command: ${command}`)
       }
@@ -30,6 +31,7 @@ export class ReactiveSpawn {
 
       childProcess.stderr.on('data', (data: Buffer) => {
         const output = data.toString()
+        errBuffer.push(output)
         subscriber.next({ origin: 'stderr', output })
       })
 
@@ -37,7 +39,7 @@ export class ReactiveSpawn {
         if (!code) {
           subscriber.complete()
         } else {
-          subscriber.error()
+          subscriber.error(errBuffer.join('\n'))
         }
       })
     })

--- a/src/commands/root.command.ts
+++ b/src/commands/root.command.ts
@@ -48,7 +48,13 @@ export class Root extends CommandRunner {
     super()
   }
 
-  async run(): Promise<void> {}
+  async run(_, options): Promise<void> {
+    console.table(options)
+
+    if (!(options.version || options.verbose || options.quiet)) {
+      this.command.help()
+    }
+  }
 
   @Option({
     flags: '--version',
@@ -60,6 +66,8 @@ export class Root extends CommandRunner {
       overrideQuiet
     )
     log(``)
+
+    return true
   }
 
   @Option({
@@ -71,6 +79,8 @@ export class Root extends CommandRunner {
   })
   doVerbose() {
     globalThis.verbose = true
+
+    return true
   }
 
   @Option({
@@ -82,6 +92,8 @@ export class Root extends CommandRunner {
   })
   doQuiet() {
     globalThis.quiet = true
+
+    return true
   }
 
   @Option({
@@ -90,5 +102,7 @@ export class Root extends CommandRunner {
   })
   doNoLog() {
     globalThis.noLog = true
+
+    return true
   }
 }

--- a/src/commands/root.command.ts
+++ b/src/commands/root.command.ts
@@ -49,8 +49,6 @@ export class Root extends CommandRunner {
   }
 
   async run(_, options): Promise<void> {
-    console.table(options)
-
     if (!(options.version || options.verbose || options.quiet)) {
       this.command.help()
     }

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -55,11 +55,7 @@ export class StartCommand extends CommandRunner {
         process.exit(1)
       },
       next: (data: Next) => {
-        if (
-          globalThis.verbose &&
-          data &&
-          data.hasOwnProperty('output')
-        ) {
+        if (globalThis.verbose && data && data.hasOwnProperty('output')) {
           logToFile(`${data.output}`)
         }
       },

--- a/src/commands/start.command.ts
+++ b/src/commands/start.command.ts
@@ -50,12 +50,16 @@ export class StartCommand extends CommandRunner {
         )
         log(`ℹ️  Logs were written to ${logFilePath}`)
       },
-      error: () => {
-        logError('❗ Error')
+      error: (errBuffer) => {
+        logError(`❗ Error:\n${errBuffer}`)
         process.exit(1)
       },
       next: (data: Next) => {
-        if (globalThis.verbose && data && data.hasOwnProperty('output')) {
+        if (
+          globalThis.verbose &&
+          data &&
+          data.hasOwnProperty('output')
+        ) {
           logToFile(`${data.output}`)
         }
       },

--- a/src/loggers.ts
+++ b/src/loggers.ts
@@ -58,13 +58,11 @@ export function logToFile(logMessage: string) {
 
 export function logError(errorMessage: string) {
   let lines = errorMessage.split('\n')
+  lines.push('For more information about the Playground, refer to the [Topos Developer Portal](https://docs.topos.technology/content/module-2/1-topos-playground.html).')
+  lines.push(`Find the full log file in ${globalThis.logFilePath}`)
 
   for (let line of lines) {
     getLogConsole().error(line)
     getLogFile().error(line)
   }
-
-  const message = `Find the full log file in ${globalThis.logFilePath}`
-  getLogConsole().error(message)
-  getLogFile().error(message)
 }


### PR DESCRIPTION
# Description

The bulk of this PR is a README update that includes more specific information on prerequisites, installing, and running the playground, as well as a troubleshooting section that covers some scenarios which people are very likely to encounter when they try to use the playground.

https://github.com/topos-protocol/topos-playground/tree/kh.revise_README

One notable omission from the README is a link back to the developer portal. That will be added as soon as we've decided that the portal is ready for external eyes to find it.

Also included in this PR, per Seb's request, is a change that lets the command line help show if there playground is taking no other action. This behavior was originally granted by the default root command, which is why it went away with the previous changes.

There is a third small change included, that came out of writing the troubleshooting section. With the previous version, if an error was encountered, the console output would show `❗ Error`, but there was no information on the console about what the error was. This is a frustrating user experience. I amended the reactify spawner to keep a buffer of STDERR output. If there is no error, nothing is done with the buffer, but if there is an error, the buffer is returned in the error response, allowing the error handler to report the error on the console. This keeps the output in the normal use case, where everything works right, clean, but still lets the tool report the error when something breaks.